### PR TITLE
Review fixes: security, UX, and CSS improvements

### DIFF
--- a/src/clj/orcpub/routes/folder.clj
+++ b/src/clj/orcpub/routes/folder.clj
@@ -7,8 +7,10 @@
   [:db/id ::folder/name {::folder/character-ids [:db/id ::se/owner ::se/summary]}])
 
 (defn create-folder [{:keys [conn identity] folder-data :transit-params}]
+  ;; Whitelist only ::folder/name from client data; owner is always server-set
   (let [username (:user identity)
-        result @(d/transact conn [(assoc folder-data ::folder/owner username)])
+        result @(d/transact conn [{::folder/name (::folder/name folder-data)
+                                   ::folder/owner username}])
         new-id (-> result :tempids first val)]
     {:status 200 :body (d/pull (d/db conn) '[*] new-id)}))
 

--- a/src/clj/orcpub/styles/core.clj
+++ b/src/clj/orcpub/styles/core.clj
@@ -1167,14 +1167,14 @@
       :align-items :center}]
 
     [:.checkbox
-     {:width "12px"
-      :height "12px"
+     {:width "16px"
+      :height "16px"
       :box-shadow "0 1px 0 0 #f0a100"
       :background-color :white
       :cursor :pointer}
 
      [:.fa-check
-      {:font-size "12px"
+      {:font-size "14px"
        :margin "1px"}]]
 
     [:.checkbox.checked.disabled
@@ -1183,6 +1183,39 @@
 
     [:.checkbox-text
      {:margin-left "5px"}]
+
+    ;; Character filter bar — scoped styles for dropdowns and checkboxes
+    [:.char-filter-bar
+     [:.filter-dropdown
+      {:position :absolute
+       :background-color "#313A4D"
+       :padding "6px 4px"
+       :top "100%"
+       :margin-top "4px"
+       :border "1px solid rgba(255,255,255,0.15)"
+       :border-radius "4px"
+       :max-height "300px"
+       :overflow-y :auto
+       :font-weight :normal
+       :font-size "14px"
+       :z-index 200
+       :box-shadow "0 4px 12px rgba(0,0,0,0.4)"}]
+     [:.filter-dropdown-item
+      {:padding "6px 10px"
+       :border-radius "3px"
+       :cursor :pointer}]
+     [:.filter-dropdown-item:hover
+      {:background-color "rgba(255,255,255,0.08)"}]
+     [:.checkbox
+      {:width "14px"
+       :height "14px"
+       :min-width "14px"
+       :flex-shrink 0}
+      [:.fa-check
+       {:font-size "12px"}]]
+     [:.flex.pointer
+      {:align-items :center
+       :gap "8px"}]]
 
     [:#selection-stepper
      {:transition "top 2s ease-in-out"

--- a/src/cljc/orcpub/components.cljc
+++ b/src/cljc/orcpub/components.cljc
@@ -3,17 +3,17 @@
             #?(:cljs [reagent.core :refer [atom]])))
 
 (defn checkbox [selected? disable?]
-  [:i.fa.fa-check.f-s-14.bg-white.b-color-gray.orange-shadow.pointer.b-3
+  [:i.fa.fa-check.f-s-14.bg-white.b-color-gray.orange-shadow.pointer.b-1
    {:class-name (str (if selected? "black slight-text-shadow" "white transparent")
                      " "
                      (if disable?
                        "opacity-5"))}])
 
 (defn labeled-checkbox [label selected? disabled? on-click]
-  [:div.flex.pointer.align-items-c
+  [:div.flex.pointer
    {:on-click on-click}
    [checkbox selected? disabled?]
-   [:span.m-l-5.align-items-c label]])
+   [:span.m-l-5 label]])
 
 (defn selection-item [key name selected?]
   [:option.builder-dropdown-item

--- a/src/cljc/orcpub/dnd/e5/folder.cljc
+++ b/src/cljc/orcpub/dnd/e5/folder.cljc
@@ -1,6 +1,7 @@
 (ns orcpub.dnd.e5.folder
   (:require [clojure.spec.alpha :as spec]))
 
+(spec/def ::owner string?)
 (spec/def ::name string?)
 (spec/def ::character-id int?)
 (spec/def ::character-ids (spec/coll-of ::character-id))

--- a/src/cljs/orcpub/dnd/e5/events.cljs
+++ b/src/cljs/orcpub/dnd/e5/events.cljs
@@ -888,10 +888,15 @@
                                :id folder-id
                                :character-id character-id)}}))
 
+;; When expanding a folder, collapse its characters so they start closed
 (reg-event-db
  ::folder5e/toggle-expanded
- (fn [db [_ folder-id]]
-   (update-in db [::folder5e/expanded folder-id] not)))
+ (fn [db [_ folder-id char-ids]]
+   (let [opening? (not (get-in db [::folder5e/expanded folder-id]))]
+     (cond-> (update-in db [::folder5e/expanded folder-id] not)
+       (and opening? (seq char-ids))
+       (update :expanded-characters
+               (fn [ec] (apply dissoc (or ec {}) char-ids)))))))
 
 (reg-event-db
  ::folder5e/toggle-renaming

--- a/src/cljs/orcpub/dnd/e5/views.cljs
+++ b/src/cljs/orcpub/dnd/e5/views.cljs
@@ -7804,21 +7804,21 @@
             renaming? @(subscribe [::folder/renaming])
             folder-renaming? (get renaming? folder-id)
             chars (::folder/character-ids f)
-            visible-chars (if (seq filtered-char-ids)
-                            (filter #(filtered-char-ids (:db/id %)) chars)
-                            chars)
+            visible-chars (filter #(filtered-char-ids (:db/id %)) chars)
             save-fn (fn []
                       (dispatch [::folder/rename-folder folder-id @edit-name])
                       (dispatch [::folder/toggle-renaming folder-id]))]
     [:div.main-text-color.item-list-item.m-b-5
      ^{:key folder-id}
      [:div
-      [:div.flex.justify-cont-s-b.align-items-c
+      ;; Entire row is clickable to expand/collapse folder
+      [:div.flex.justify-cont-s-b.align-items-c.pointer
+       {:on-click (when (not folder-renaming?)
+                    #(dispatch [::folder/toggle-expanded folder-id (mapv :db/id chars)]))}
        [:div.flex.align-items-c.m-l-10
         (when (not folder-renaming?)
-          [:i.fa.m-r-10.orange.pointer
-           {:class-name (if folder-expanded? "fa-folder-open" "fa-folder")
-            :on-click (make-event-handler ::folder/toggle-expanded folder-id)}])
+          [:i.fa.m-r-10.orange
+           {:class-name (if folder-expanded? "fa-folder-open" "fa-folder")}])
         (if folder-renaming?
           [:div.flex.align-items-c
            [:input.input
@@ -7834,8 +7834,7 @@
                          (.stopPropagation e)
                          (save-fn))}
             "save"]]
-          [:span.f-s-18.f-w-b.pointer
-           {:on-click (make-event-handler ::folder/toggle-expanded folder-id)}
+          [:span.f-s-18.f-w-b
            folder-name])
         (when (not folder-renaming?)
           [:span.m-l-10.f-s-12.opacity-5
@@ -7853,9 +7852,8 @@
                         (.stopPropagation e)
                         (reset! confirm-delete? true))}
            "delete"]
-          [:i.fa.m-l-10.orange.pointer
-           {:class-name (if folder-expanded? "fa-caret-up" "fa-caret-down")
-            :on-click   (make-event-handler ::folder/toggle-expanded folder-id)}]])]
+          [:i.fa.m-l-10.orange
+           {:class-name (if folder-expanded? "fa-caret-up" "fa-caret-down")}]])]
       (when @confirm-delete?
         [:div.p-20.flex.justify-cont-end
          [:div
@@ -7908,7 +7906,7 @@
                                  (seq class-filters)
                                  has-portrait?
                                  has-faction-pic?)]
-        [:div.main-text-color.m-b-10
+        [:div.main-text-color.m-b-10.char-filter-bar
          (when @classes-open?
            [:div.posn-fixed
             {:style    {:top 0 :left 0 :right 0 :bottom 0 :z-index 100}
@@ -7938,27 +7936,17 @@
             (str "Classes" (when (seq class-filters) (str " (" (count class-filters) ")")))
             [:i.fa.m-l-5 {:class-name (if @classes-open? "fa-caret-up" "fa-caret-down")}]]
            (when @classes-open?
-             [:div.posn-abs.main-text-color
-              {:style {:z-index      200
-                       :background   "rgba(0,0,0,0.92)"
-                       :padding      "10px"
-                       :min-width    "160px"
-                       :top          "105%"
-                       :border       "1px solid rgba(255,255,255,0.15)"
-                       :border-radius "4px"
-                       :max-height   "300px"
-                       :overflow-y   "auto"
-                       :font-weight  "normal"
-                       :font-size    "small"}}
+             [:div.filter-dropdown.main-text-color
+              {:style {:min-width "160px"}}
               (if (seq avail-classes)
                 (doall
                  (map (fn [cls]
                         ^{:key cls}
-                        [:div {:style {:margin-bottom "3px"}}
+                        [:div.filter-dropdown-item
                          [comps/labeled-checkbox cls (contains? class-filters cls) false
                           (fn [] (dispatch [::char/toggle-char-class-filter cls]))]])
                       avail-classes))
-                [:span.opacity-5.f-s-12 "No classes yet"])])]
+                [:span.opacity-5.f-s-12.p-5 "No classes yet"])])]
 
           ;; Levels multi-select dropdown
           [:div.posn-rel.m-r-5.m-b-5
@@ -7968,27 +7956,17 @@
             (str "Levels" (when (seq level-filters) (str " (" (count level-filters) ")")))
             [:i.fa.m-l-5 {:class-name (if @levels-open? "fa-caret-up" "fa-caret-down")}]]
            (when @levels-open?
-             [:div.posn-abs.main-text-color.center
-              {:style {:z-index       200
-                       :background    "rgba(0,0,0,0.92)"
-                       :padding       "10px"
-                       :min-width     "110px"
-                       :top           "105%"
-                       :border        "1px solid rgba(255,255,255,0.15)"
-                       :border-radius "4px"
-                       :max-height    "300px"
-                       :overflow-y    "auto"
-                       :font-weight   "normal"
-                       :font-size     "small"}}
+             [:div.filter-dropdown.main-text-color
+              {:style {:min-width "120px"}}
               (if (seq avail-levels)
                 (doall
                  (map (fn [lvl]
                         ^{:key lvl}
-                        [:div {:style {:margin-bottom "3px"}}
+                        [:div.filter-dropdown-item
                          [comps/labeled-checkbox (str "Level " lvl) (contains? level-filters lvl) false
                           (fn [] (dispatch [::char/toggle-char-level-filter lvl]))]])
                       avail-levels))
-                [:span.opacity-5.f-s-12 "No levels yet"])])]
+                [:span.opacity-5.f-s-12.p-5 "No levels yet"])])]
 
           ;; Portrait toggle (nil=all, true=with portrait, false=without portrait)
           [:button.form-button.m-r-5.m-b-5


### PR DESCRIPTION
Fixes / Closes #52 

Fixes and improvements from reviewing the character folders feature (#642), tested against a local dev server.

- **Security**: Whitelist `transit-params` in `create-folder` so clients can't inject arbitrary Datomic attributes
- **Spec**: Add missing `::owner` spec to folder schema
- **Dead code**: Remove unreachable conditional in `visible-chars` filtering
- **CSS**: Scope dropdown styles to `.char-filter-bar` instead of modifying global checkbox — prevents regressions elsewhere in the app
- **Dropdown styling**: Match app palette (`#313A4D`), larger touch targets, hover highlights, drop shadow
- **Folder UX**: Entire row is clickable to expand/collapse (not just the icon/text)
- **Folder UX**: Characters inside a folder start collapsed when the folder is opened

## Files changed

| File | What |
|------|------|
| `src/clj/orcpub/routes/folder.clj` | Whitelist folder creation params |
| `src/cljc/orcpub/dnd/e5/folder.cljc` | Add `::owner` spec |
| `src/cljs/orcpub/dnd/e5/views.cljs` | Remove dead conditional, use CSS classes for dropdowns, clickable folder row |
| `src/cljs/orcpub/dnd/e5/events.cljs` | Collapse characters on folder expand |
| `src/clj/orcpub/styles/core.clj` | Revert global checkbox, add scoped `.char-filter-bar` styles |
| `src/cljc/orcpub/components.cljc` | Revert checkbox border back to original `b-1` |

## Test

- [x] Create a folder — verify it saves only name and owner
- [x] Open filter dropdowns (Classes, Levels) — background matches app theme, items have hover highlight, touch-friendly spacing
- [x] Click anywhere on a folder row — folder expands/collapses
- [x] Expand a folder — characters inside should be collapsed
- [x] Verify checkboxes elsewhere in the app (character builder, etc.) are unchanged