### PR TITLE
Harden email change flow: fixes, rate limiting, tests, docs

### DIFF
--- a/docs/email-system.md
+++ b/docs/email-system.md
@@ -1,0 +1,155 @@
+# Email System
+
+Overview of email-related flows, schema, configuration, and behavior.
+
+## Configuration
+
+All email is sent via [postal](https://github.com/drewr/postal) using SMTP credentials from environment variables:
+
+| Env var | Purpose |
+|---------|---------|
+| `EMAIL_ACCESS_KEY` | SMTP username |
+| `EMAIL_SECRET_KEY` | SMTP password |
+| `EMAIL_SERVER_URL` | SMTP host |
+| `EMAIL_SERVER_PORT` | SMTP port (default `587`) |
+| `EMAIL_SSL` | Enable SSL (`true`/`false`) |
+| `EMAIL_TLS` | Enable TLS (`true`/`false`) |
+| `EMAIL_FROM_ADDRESS` | Sender address (default `no-reply@orcpub.com`) |
+| `EMAIL_ERRORS_TO` | Address for error notification emails (optional) |
+
+Configuration is read at send-time by `email/email-cfg` (`src/clj/orcpub/email.clj`).
+
+## Schema
+
+User attributes related to email and verification (`src/clj/orcpub/db/schema.clj`):
+
+| Attribute | Type | Purpose |
+|-----------|------|---------|
+| `:orcpub.user/email` | string | Confirmed email address |
+| `:orcpub.user/pending-email` | string | Requested new email (awaiting verification) |
+| `:orcpub.user/verified?` | boolean | Whether the user has verified their email |
+| `:orcpub.user/verification-key` | string | UUID used in verification links |
+| `:orcpub.user/verification-sent` | instant | When the verification email was sent |
+| `:orcpub.user/password-reset-key` | string | UUID used in password reset links |
+| `:orcpub.user/password-reset-sent` | instant | When the password reset email was sent |
+| `:orcpub.user/password-reset` | instant | When the password was actually reset |
+
+**Note:** `:orcpub.user/email` has no uniqueness constraint in the schema. Uniqueness is enforced at the application level via `email-query`. See the known issues section.
+
+## Flows
+
+### 1. Registration Verification
+
+**Trigger:** `POST /register` (via `routes/register`)
+
+1. Validate username, email, password
+2. Check email/username not already taken (`email-query`, `username-query`)
+3. Create user entity with `verified? false`, generate `verification-key`, set `verification-sent`
+4. Send registration verification email (`email/send-verification-email`)
+5. User clicks link → `GET /verify?key=...` → `routes/verify`
+
+**Verify behavior (registration path):**
+- If already verified and no `pending-email` → redirect to success
+- If `verification-sent` is nil or expired (24h) → redirect to failed
+- Otherwise → set `verified? true`, redirect to success
+
+**Re-verify:** `GET /re-verify?email=...` (`routes/re-verify`) re-sends the verification email for unverified accounts.
+
+**Login gate:** Unverified users cannot log in. If the verification has expired, the login error tells them to re-register.
+
+**Files:** `routes.clj:register`, `routes.clj:do-verification`, `routes.clj:verify`, `email.clj:send-verification-email`
+
+### 2. Email Change
+
+**Trigger:** `PUT /user/email` (via `routes/request-email-change`, requires auth)
+
+1. Validate new email (format, not same as current, not already taken)
+2. Check rate limit (see Rate Limiting below)
+3. Store `pending-email`, generate new `verification-key`, set `verification-sent`
+4. Send email-change verification to the **new** address (`email/send-email-change-verification`)
+5. If send fails → full rollback (retract `pending-email`, `verification-key`, `verification-sent`), return 500
+
+**Verify behavior (email-change path):**
+- If expired (24h) → retract `pending-email`, `verification-key`, `verification-sent`; redirect to failed
+- If `pending-email` exists → re-check email availability (race-condition guard):
+  - If email was claimed by another user since request → retract all pending state, redirect to failed
+  - Otherwise → swap `email` to `pending-email`, retract `pending-email`, `verification-key`, `verification-sent`; redirect to success
+- Key is invalidated after use (retracted) — link cannot be reused
+
+**Free resend:** Within 1–5 minutes of the original request, resending the same email re-uses the existing `verification-key` and does not update `verification-sent` (no rolling window). See Rate Limiting.
+
+**Files:** `routes.clj:request-email-change`, `routes.clj:verify` (pending-email branch), `email.clj:send-email-change-verification`, `events.cljs:change-email`, `views.cljs:my-account-page`
+
+### 3. Password Reset
+
+**Trigger:** `GET /send-password-reset?email=...` (via `routes/send-password-reset`)
+
+1. Look up user by email
+2. Generate `password-reset-key`, set `password-reset-sent`
+3. Send password reset email (`email/send-reset-email`)
+
+**Reset behavior:** `POST /reset-password` (via `routes/reset-password`)
+- Validates new password and password match
+- Sets new password hash, sets `password-reset` timestamp, sets `verified? true`
+
+**Expiration:** `password-reset-expired?` checks if `password-reset-sent` is older than 24 hours.
+
+**Files:** `routes.clj:send-password-reset`, `routes.clj:do-send-password-reset`, `routes.clj:reset-password`, `email.clj:send-reset-email`
+
+### 4. Error Notification
+
+**Trigger:** Called from exception handlers (e.g., Pedestal error interceptor)
+
+- Sends a plaintext email with the request context and exception data
+- Only sends if `EMAIL_ERRORS_TO` is set
+- Uses `email/send-error-email`
+
+**Files:** `email.clj:send-error-email`
+
+## Rate Limiting (Email Change)
+
+Rate limiting is enforced by `routes/email-change-rate-limited?` based on `verification-sent` and whether the request is a resend (same email as `pending-email`).
+
+Three zones measured from `verification-sent`:
+
+```
+0 ──────── 1 min ──────── 5 min ──────── ∞
+│  BLOCKED  │  FREE RESEND │   OPEN      │
+│ (transit) │ (same email) │ (any email) │
+│           │  blocked for │             │
+│           │  diff email  │             │
+```
+
+- **0–1 min:** All requests blocked. Email is in transit. Client shows "Your email is on its way. You can resend in N seconds."
+- **1–5 min:** Resend of same email allowed (free resend, no DB write, reuses existing key). Different email blocked. Client shows "Please wait N minutes before requesting another change."
+- **5+ min:** Any request allowed. New `verification-key` generated, `verification-sent` updated.
+
+The 429 response includes `retry-after-secs` so the client can display a specific countdown.
+
+## Expiration Windows
+
+| Window | Duration | Function |
+|--------|----------|----------|
+| Verification link | 24 hours | `verification-expired?` |
+| Password reset link | 24 hours | `password-reset-expired?` |
+| Email change rate limit | 5 minutes | `email-change-rate-limited?` |
+| Free resend grace | 1–5 minutes | `email-change-rate-limited?` + free resend branch |
+
+## File Map
+
+| File | Role |
+|------|------|
+| `src/clj/orcpub/email.clj` | Email templates and send functions (postal) |
+| `src/clj/orcpub/routes.clj` | Server handlers: register, verify, email change, password reset |
+| `src/clj/orcpub/db/schema.clj` | Datomic schema for user attributes |
+| `src/cljc/orcpub/route_map.cljc` | Route definitions (shared server/client) |
+| `src/cljs/orcpub/dnd/e5/events.cljs` | Re-frame events for email change UI |
+| `src/cljs/orcpub/dnd/e5/views.cljs` | My Account page with email change form |
+| `src/cljs/orcpub/dnd/e5/subs.cljs` | Subscriptions for pending-email, email-change state |
+| `test/clj/orcpub/email_change_test.clj` | Email change tests (11 tests, datomock) |
+
+## Known Issues
+
+- **No uniqueness constraint on email in schema.** Uniqueness is enforced at the application level by `email-query` (at request time) and a race-condition guard (at verify time). A Datomic `:db.unique/value` constraint on `:orcpub.user/email` would be the proper fix but requires a data migration to handle any existing duplicates.
+
+- **Pending-email conflicts not checked.** Two users can simultaneously request the same new email. Both receive verification emails, but only the first to verify succeeds — the second is caught by the race-condition guard. The "loser" gets a confusing failure after clicking a valid-looking link.

--- a/src/clj/orcpub/email.clj
+++ b/src/clj/orcpub/email.clj
@@ -27,6 +27,32 @@
   [{:type "text/html"
     :content (hiccup/html (verification-email-html first-and-last-name username verification-url))}])
 
+(defn email-change-verification-html
+  "Email body for existing users changing their email (distinct from registration)."
+  [username verification-url]
+  [:div
+   "Dear OrcPub Patron,"
+   [:br]
+   [:br]
+   "You requested to change the email address on your OrcPub account (" username "). "
+   "Please visit the following URL to confirm this change:"
+   [:br]
+   [:br]
+   [:a {:href verification-url} verification-url]
+   [:br]
+   [:br]
+   "If you did not request this change, you can safely ignore this email."
+   [:br]
+   [:br]
+   "Sincerely,"
+   [:br]
+   [:br]
+   "The OrcPub Team"])
+
+(defn email-change-verification-email [username verification-url]
+  [{:type "text/html"
+    :content (hiccup/html (email-change-verification-html username verification-url))}])
+
 (defn email-cfg []
   (let [cfg {:user (environ/env :email-access-key)
              :pass (environ/env :email-secret-key)
@@ -34,11 +60,6 @@
              :port (Integer/parseInt (or (environ/env :email-server-port) "587"))
              :ssl  (or (str/to-bool (environ/env :email-ssl)) nil)
              :tls  (or (str/to-bool (environ/env :email-tls)) nil)}]
-    (println "[email-cfg] host=" (:host cfg)
-             "user=" (:user cfg)
-             "port=" (:port cfg)
-             "ssl=" (:ssl cfg)
-             "tls=" (:tls cfg))
     cfg))
 
 (defn emailfrom []
@@ -51,6 +72,17 @@
                         :subject "OrcPub Email Verification"
                         :body (verification-email
                                first-and-last-name
+                               username
+                               (str base-url (routes/path-for routes/verify-route) "?key=" verification-key))}))
+
+(defn send-email-change-verification
+  "Send a verification email for an email-change request (not registration)."
+  [base-url {:keys [email username]} verification-key]
+  (postal/send-message (email-cfg)
+                       {:from (str "OrcPub Team <" (emailfrom) ">")
+                        :to email
+                        :subject "OrcPub Email Change Verification"
+                        :body (email-change-verification-email
                                username
                                (str base-url (routes/path-for routes/verify-route) "?key=" verification-key))}))
 

--- a/src/clj/orcpub/routes.clj
+++ b/src/clj/orcpub/routes.clj
@@ -68,10 +68,13 @@
     :in $ ?username
     :where [?e :orcpub.user/username ?username]])
 
+;; Case-insensitive email lookup to guard against mixed-case legacy data.
+;; Callers must pass a lowercased email.
 (def email-query
   '[:find ?e
     :in $ ?email
-    :where [?e :orcpub.user/email ?email]])
+    :where [?e :orcpub.user/email ?stored]
+           [(clojure.string/lower-case ?stored) ?email]])
 
 (defn find-user-by-username-or-email [db username-or-email]
   (d/q
@@ -269,6 +272,12 @@
    params
    verification-key))
 
+(defn send-email-change-verification [request params verification-key]
+  (email/send-email-change-verification
+   (base-url request)
+   params
+   verification-key))
+
 (defn do-verification [request params conn & [tx-data]]
   (let [verification-key (str (java.util.UUID/randomUUID))
         now (java.util.Date.)]
@@ -341,14 +350,29 @@
 
           (or (nil? verification-sent)
               (verification-expired? verification-sent))
-          (redirect route-map/verify-failed-route)
+          ;; Clean up stale pending state so user can request a fresh change
+          (do (let [retractions (cond-> [[:db/retract id :orcpub.user/verification-key key]
+                                         [:db/retract id :orcpub.user/verification-sent verification-sent]]
+                                  pending-email
+                                  (conj [:db/retract id :orcpub.user/pending-email pending-email]))]
+                @(d/transact conn retractions))
+              (redirect route-map/verify-failed-route))
 
           pending-email
-          (do @(d/transact conn [{:db/id id
-                                  :orcpub.user/email pending-email
-                                  :orcpub.user/verified? true}
-                                 [:db/retract id :orcpub.user/pending-email pending-email]])
-              (redirect route-map/verify-success-route))
+          ;; Guard: re-check that the target email hasn't been claimed since request.
+          ;; All paths retract verification-key and verification-sent to prevent
+          ;; link reuse and avoid stale rate-limit data.
+          (if (seq (d/q email-query (d/db conn) pending-email))
+            (do @(d/transact conn [[:db/retract id :orcpub.user/pending-email pending-email]
+                                   [:db/retract id :orcpub.user/verification-key key]
+                                   [:db/retract id :orcpub.user/verification-sent verification-sent]])
+                (redirect route-map/verify-failed-route))
+            (do @(d/transact conn [{:db/id id
+                                    :orcpub.user/email pending-email}
+                                   [:db/retract id :orcpub.user/pending-email pending-email]
+                                   [:db/retract id :orcpub.user/verification-key key]
+                                   [:db/retract id :orcpub.user/verification-sent verification-sent]])
+                (redirect route-map/verify-success-route)))
 
           :else
           (do @(d/transact conn [{:db/id id
@@ -609,7 +633,7 @@
   (check-field username-query (:username query-params) db))
 
 (defn check-email [{:keys [db query-params]}]
-  (check-field email-query (:email query-params) db))
+  (check-field email-query (some-> (:email query-params) s/lower-case) db))
 
 (defn character-for-id [db id]
   (d/pull db '[*] id))
@@ -910,54 +934,104 @@
     @(d/transact conn [[:db/retractEntity user]])
     {:status 200}))
 
-(defn email-change-rate-limited? [verification-sent pending-email]
+(defn rate-limit-remaining-secs
+  "Seconds until the user can act again. In the 0–1 min zone (email in transit)
+   returns time until the 1-min resend window opens. In the 1–5 min zone (for a
+   different email) returns time until the 5-min cooldown expires."
+  [verification-sent new-email pending-email]
+  (when verification-sent
+    (let [elapsed-ms (- (System/currentTimeMillis) (.getTime ^java.util.Date verification-sent))
+          ;; If same email, they're waiting for the 1-min resend window to open.
+          ;; If different email, they're waiting for the full 5-min cooldown.
+          target-ms (if (= new-email pending-email)
+                      (* 1 60 1000)
+                      (* 5 60 1000))
+          remaining-ms (- target-ms elapsed-ms)]
+      (when (pos? remaining-ms)
+        (int (Math/ceil (/ remaining-ms 1000.0)))))))
+
+(defn email-change-rate-limited? [verification-sent pending-email new-email]
   ;; Only rate-limit if the last key was generated for a pending email change
   ;; (not for initial registration verification).
-  ;; Allow at most one request per 5 minutes.
+  ;; Three zones from verification-sent:
+  ;;   0–1 min  → too soon, email is in transit (always blocked)
+  ;;   1–5 min  → free resend allowed for same email, otherwise blocked
+  ;;   5+ min   → open for any request
   (and pending-email
        verification-sent
-       (t/before? (-> 5 t/minutes t/ago) (tc/from-date verification-sent))))
+       (let [elapsed-ms (- (System/currentTimeMillis) (.getTime ^java.util.Date verification-sent))
+             same-email? (= new-email pending-email)]
+         (cond
+           (>= elapsed-ms (* 5 60 1000)) false          ;; past cooldown
+           (< elapsed-ms (* 1 60 1000))  true           ;; too soon
+           :else                          (not same-email?)))) ;; 1-5 min: resend ok, new email blocked
+  )
 
 (defn request-email-change [{:keys [transit-params db conn identity] :as request}]
   (try
-    (let [new-email (s/lower-case (s/trim (str transit-params)))
-          username (:user identity)
-          {:keys [:db/id
-                  :orcpub.user/email
-                  :orcpub.user/pending-email
-                  :orcpub.user/verification-sent] :as user} (find-user-by-username db username)]
-      (cond
-        (nil? id)
+    ;; Client sends {:new-email "..."} (confirm-email is validated client-side only)
+    (let [new-email (s/lower-case (s/trim (str (:new-email transit-params))))
+          username (:user identity)]
+      (if (nil? username)
         {:status 400 :body {:error :user-not-found}}
+        (let [{:keys [:db/id
+                      :orcpub.user/email
+                      :orcpub.user/pending-email
+                      :orcpub.user/verification-sent] :as user} (find-user-by-username db username)]
+          (cond
+            (nil? id)
+            {:status 400 :body {:error :user-not-found}}
 
-        (registration/bad-email? new-email)
-        {:status 400 :body {:error :invalid-email}}
+            (registration/bad-email? new-email)
+            {:status 400 :body {:error :invalid-email}}
 
-        (= new-email (some-> email s/lower-case))
-        {:status 400 :body {:error :same-as-current}}
+            (= new-email (some-> email s/lower-case))
+            {:status 400 :body {:error :same-as-current}}
 
-        (email-change-rate-limited? verification-sent pending-email)
-        {:status 429 :body {:error :too-many-requests}}
+            (email-change-rate-limited? verification-sent pending-email new-email)
+            {:status 429 :body {:error :too-many-requests
+                                :retry-after-secs (rate-limit-remaining-secs verification-sent new-email pending-email)}}
 
-        ;; Check no other account already owns this email
-        (seq (d/q email-query db new-email))
-        {:status 400 :body {:error :email-taken}}
+            ;; Check no other account already owns this email
+            (seq (d/q email-query db new-email))
+            {:status 400 :body {:error :email-taken}}
 
-        :else
-        (let [verification-key (str (java.util.UUID/randomUUID))
-              now (java.util.Date.)]
-          @(d/transact conn [{:db/id id
-                              :orcpub.user/pending-email new-email
-                              :orcpub.user/verification-key verification-key
-                              :orcpub.user/verification-sent now}])
-          (try
-            (send-verification-email request
-                                     {:email new-email
-                                      :first-and-last-name "OrcPub Patron"}
-                                     verification-key)
-            (catch Throwable e
-              (prn "Warning: email sending failed (check SMTP config):" (.getMessage e))))
-          {:status 200})))
+            ;; Free resend: same email, 1–5 min after original send. Re-send with
+            ;; existing key and don't update verification-sent (no rolling window).
+            (and (= new-email pending-email)
+                 verification-sent
+                 (let [elapsed (- (System/currentTimeMillis) (.getTime ^java.util.Date verification-sent))]
+                   (and (>= elapsed (* 1 60 1000))
+                        (< elapsed (* 5 60 1000)))))
+            (try
+              (send-email-change-verification request
+                                              {:email new-email :username username}
+                                              (:orcpub.user/verification-key user))
+              {:status 200 :body {:pending-email new-email}}
+              (catch Throwable e
+                (prn "Email resend failed:" (.getMessage e))
+                {:status 500 :body {:error :email-send-failed}}))
+
+            :else
+            (let [verification-key (str (java.util.UUID/randomUUID))
+                  now (java.util.Date.)]
+              @(d/transact conn [{:db/id id
+                                  :orcpub.user/pending-email new-email
+                                  :orcpub.user/verification-key verification-key
+                                  :orcpub.user/verification-sent now}])
+              ;; Roll back pending-email if verification email fails to send
+              (try
+                (send-email-change-verification request
+                                                {:email new-email :username username}
+                                                verification-key)
+                {:status 200 :body {:pending-email new-email}}
+                (catch Throwable e
+                  (prn "Email send failed, rolling back pending state:" (.getMessage e))
+                  ;; Full rollback: retract all attributes set by the failed attempt
+                  @(d/transact conn [[:db/retract id :orcpub.user/pending-email new-email]
+                                     [:db/retract id :orcpub.user/verification-key verification-key]
+                                     [:db/retract id :orcpub.user/verification-sent now]])
+                  {:status 500 :body {:error :email-send-failed}})))))))
     (catch Throwable e (prn e) (throw e))))
 
 (defn character-summary-description [{:keys [::char5e/race-name ::char5e/subrace-name ::char5e/classes]}]

--- a/src/cljs/orcpub/dnd/e5/events.cljs
+++ b/src/cljs/orcpub/dnd/e5/events.cljs
@@ -981,25 +981,41 @@
     :http {:method :put
            :headers (authorization-headers db)
            :url (backend-url (routes/path-for routes/user-email-route))
-           :transit-params new-email
+           :transit-params {:new-email new-email}
            :on-success [:change-email-success]
            :on-failure [:change-email-failure]}}))
 
 (reg-event-db
  :change-email-success
- (fn [db _]
-   (assoc db :email-change-sent? true)))
+ (fn [db [_ response]]
+   (-> db
+       (assoc :email-change-sent? true)
+       ;; Use server-canonical (lowercased/trimmed) email for display
+       (assoc-in [:user-data :user-data :pending-email]
+                 (-> response :body :pending-email)))))
 
 (reg-event-db
  :change-email-failure
  (fn [db [_ response]]
-   (assoc db :email-change-error
-          (case (-> response :body :error)
-            :email-taken "That email address is already in use by another account."
-            :invalid-email "Please enter a valid email address."
-            :same-as-current "That is already your current email address."
-            :too-many-requests "Please wait a few minutes before requesting another email change."
-            "There was an error updating your email. Please try again."))))
+   (let [body (:body response)
+         error (:error body)]
+     (assoc db :email-change-error
+            (case error
+              :email-taken "That email address is already in use by another account."
+              :invalid-email "Please enter a valid email address."
+              :same-as-current "That is already your current email address."
+              :too-many-requests
+              (let [secs (:retry-after-secs body)]
+                (if (and secs (pos? secs))
+                  (if (<= secs 60)
+                    ;; 0–1 min zone: email is in transit, show short countdown
+                    (str "Your email is on its way. You can resend in " secs " second" (when (> secs 1) "s") ".")
+                    ;; 1–5 min zone for a different email: show minutes
+                    (let [mins (.ceil js/Math (/ secs 60))]
+                      (str "Please wait " mins " minute" (when (> mins 1) "s") " before requesting another change.")))
+                  "Please wait a few minutes before requesting another email change."))
+              :email-send-failed "Verification email could not be sent. Please try again later."
+              "There was an error updating your email. Please try again.")))))
 
 (reg-event-db
  :change-email-clear

--- a/src/cljs/orcpub/dnd/e5/views.cljs
+++ b/src/cljs/orcpub/dnd/e5/views.cljs
@@ -7502,11 +7502,20 @@
 
 (defn my-account-page []
   (r/with-let [editing? (r/atom false)
-               new-email (r/atom "")]
+               new-email (r/atom "")
+               confirm-email (r/atom "")]
     (let [current-email @(subscribe [:email])
           pending-email @(subscribe [:pending-email])
           sent? @(subscribe [:email-change-sent?])
-          error @(subscribe [:email-change-error])]
+          error @(subscribe [:email-change-error])
+          ;; Client-side validation: format check + confirm match
+          bad-format? (and (seq @new-email)
+                          (registration/bad-email? @new-email))
+          emails-dont-match? (and (seq @confirm-email)
+                                  (not= @new-email @confirm-email))
+          can-submit? (and (seq @new-email)
+                           (not bad-format?)
+                           (= @new-email @confirm-email))]
       [content-page
        "My Account"
        [{:title (str "Delete Account")
@@ -7526,10 +7535,11 @@
            sent?
            [:div
             [:span current-email]
-            [:div.m-t-5.f-s-14 "A verification email has been sent to your new address. Click the link in that email to confirm the change."]
+            [:div.m-t-5.f-s-14 "A verification email has been sent to " [:strong pending-email] ". Click the link in that email to confirm the change."]
             [:button.link-button.m-t-5.f-s-14
              {:on-click #(do (reset! editing? true)
                              (reset! new-email "")
+                             (reset! confirm-email "")
                              (dispatch [:change-email-clear]))}
              "Change again"]]
 
@@ -7540,13 +7550,26 @@
               :value @new-email
               :placeholder "New email address"
               :on-change #(reset! new-email (event-value %))}]
+            (when bad-format?
+              [:div.m-t-5.red "Not a valid email format"])
+            ;; Confirm field to prevent typo-induced lockout
+            [:input.input.m-t-5
+             {:type :email
+              :value @confirm-email
+              :placeholder "Confirm new email address"
+              :on-change #(reset! confirm-email (event-value %))}]
+            (when emails-dont-match?
+              [:div.m-t-5.red "Email addresses don't match"])
             [:div.m-t-5
              [:button.form-button
-              {:on-click #(dispatch [:change-email @new-email])}
+              {:disabled (not can-submit?)
+               :on-click #(when can-submit?
+                            (dispatch [:change-email @new-email]))}
               "Save"]
              [:button.link-button.m-l-10
               {:on-click #(do (reset! editing? false)
                               (reset! new-email "")
+                              (reset! confirm-email "")
                               (dispatch [:change-email-clear]))}
               "Cancel"]]
             (when error
@@ -7556,10 +7579,19 @@
            [:div
             [:span current-email]
             (when pending-email
-              [:div.m-t-5.f-s-14 "Pending: " pending-email " — check your email to verify the change."])
+              [:div.m-t-5.f-s-14
+               "Pending: " pending-email " — check your email to verify the change. "
+               ;; Resend uses the same change-email flow; server enforces 3-zone rate limit
+               ;; (0–1 min blocked, 1–5 min free resend, 5+ min open)
+               [:button.link-button.f-s-14
+                {:on-click #(dispatch [:change-email pending-email])}
+                "Resend"]
+               (when error
+                 [:span.m-l-5.red.f-s-14 error])])
             [:button.link-button.m-l-10
              {:on-click #(do (reset! editing? true)
                              (reset! new-email "")
+                             (reset! confirm-email "")
                              (dispatch [:change-email-clear]))}
              "Change"]])]]])))
 

--- a/test/clj/orcpub/email_change_test.clj
+++ b/test/clj/orcpub/email_change_test.clj
@@ -1,0 +1,313 @@
+(ns orcpub.email-change-test
+  "Tests for the email change flow (PR #644).
+   Uses datomock for in-memory Datomic and with-redefs to stub email sending."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [datomic.api :as d]
+   [datomock.core :as dm]
+   [buddy.hashers :as hashers]
+   [orcpub.routes :as routes]
+   [orcpub.route-map :as route-map]
+   [orcpub.db.schema :as schema])
+  (:import [java.util UUID]))
+
+(defmacro with-conn [conn-binding & body]
+  `(let [uri# (str "datomic:mem:email-change-test-" (UUID/randomUUID))
+         ~conn-binding (do
+                         (d/create-database uri#)
+                         (d/connect uri#))]
+     (try ~@body
+          (finally (d/delete-database uri#)))))
+
+(defn seed-users
+  "Transact schema and seed two verified users for testing."
+  [conn]
+  @(d/transact conn schema/all-schemas)
+  @(d/transact conn
+    [{:orcpub.user/username   "alice"
+      :orcpub.user/email      "alice@test.com"
+      :orcpub.user/password   (hashers/encrypt "pass123")
+      :orcpub.user/verified?  true}
+     {:orcpub.user/username   "bob"
+      :orcpub.user/email      "bob@test.com"
+      :orcpub.user/password   (hashers/encrypt "pass456")
+      :orcpub.user/verified?  true}]))
+
+(defn make-request
+  "Build a minimal request map for request-email-change."
+  [conn new-email username]
+  {:transit-params {:new-email new-email}
+   :db             (d/db conn)
+   :conn           conn
+   :identity       {:user username}
+   ;; send-email-change-verification reads scheme + headers for base-url
+   :scheme         :https
+   :headers        {"host" "localhost"}})
+
+(defn find-user [db username]
+  (d/q '[:find (pull ?e [:orcpub.user/email
+                         :orcpub.user/pending-email
+                         :orcpub.user/verification-key
+                         :orcpub.user/verification-sent
+                         :orcpub.user/verified?
+                         :db/id]) .
+         :in $ ?username
+         :where [?e :orcpub.user/username ?username]]
+       db username))
+
+(def success-path (route-map/path-for route-map/verify-success-route))
+(def failed-path (route-map/path-for route-map/verify-failed-route))
+
+(defn redirect-location
+  "Extract the Location header from a redirect response."
+  [resp]
+  (get-in resp [:headers "Location"]))
+
+;; ---------- Tests ----------
+
+(deftest test-email-change-happy-path
+  (with-conn conn
+    (let [mocked-conn (dm/fork-conn conn)]
+      (seed-users mocked-conn)
+      (testing "Request email change stores pending-email and returns 200"
+        (with-redefs [routes/send-email-change-verification (fn [& _] nil)]
+          (let [resp (routes/request-email-change
+                       (make-request mocked-conn "newalice@test.com" "alice"))]
+            (is (= 200 (:status resp)))
+            (let [user (find-user (d/db mocked-conn) "alice")]
+              (is (= "newalice@test.com" (:orcpub.user/pending-email user)))
+              (is (some? (:orcpub.user/verification-key user)))
+              ;; Original email unchanged until verified
+              (is (= "alice@test.com" (:orcpub.user/email user)))
+
+              (testing "Verify link swaps email and clears pending-email"
+                (let [key   (:orcpub.user/verification-key user)
+                      vresp (routes/verify {:query-params {:key key}
+                                            :db           (d/db mocked-conn)
+                                            :conn         mocked-conn})]
+                  (is (= 302 (:status vresp)))
+                  ;; Must redirect to success, not failure
+                  (is (= success-path (redirect-location vresp)))
+                  (let [updated (find-user (d/db mocked-conn) "alice")]
+                    (is (= "newalice@test.com" (:orcpub.user/email updated)))
+                    (is (nil? (:orcpub.user/pending-email updated)))
+                    ;; Verification key invalidated — link can't be reused
+                    (is (nil? (:orcpub.user/verification-key updated)))))))))))))
+
+(deftest test-email-change-duplicate-rejected
+  (with-conn conn
+    (let [mocked-conn (dm/fork-conn conn)]
+      (seed-users mocked-conn)
+      (testing "Changing to an already-taken email returns 400 :email-taken"
+        (with-redefs [routes/send-email-change-verification (fn [& _] nil)]
+          (let [resp (routes/request-email-change
+                       (make-request mocked-conn "bob@test.com" "alice"))]
+            (is (= 400 (:status resp)))
+            (is (= :email-taken (-> resp :body :error)))
+            ;; DB unchanged
+            (let [user (find-user (d/db mocked-conn) "alice")]
+              (is (= "alice@test.com" (:orcpub.user/email user)))
+              (is (nil? (:orcpub.user/pending-email user))))))))))
+
+(deftest test-email-change-same-as-current
+  (with-conn conn
+    (let [mocked-conn (dm/fork-conn conn)]
+      (seed-users mocked-conn)
+      (testing "Changing to your own current email returns 400 :same-as-current"
+        (with-redefs [routes/send-email-change-verification (fn [& _] nil)]
+          (let [resp (routes/request-email-change
+                       (make-request mocked-conn "alice@test.com" "alice"))]
+            (is (= 400 (:status resp)))
+            (is (= :same-as-current (-> resp :body :error)))
+            ;; DB unchanged
+            (let [user (find-user (d/db mocked-conn) "alice")]
+              (is (= "alice@test.com" (:orcpub.user/email user)))
+              (is (nil? (:orcpub.user/pending-email user))))))))))
+
+(deftest test-email-change-invalid-format
+  (with-conn conn
+    (let [mocked-conn (dm/fork-conn conn)]
+      (seed-users mocked-conn)
+      (testing "Badly formatted email returns 400 :invalid-email"
+        (with-redefs [routes/send-email-change-verification (fn [& _] nil)]
+          (let [resp (routes/request-email-change
+                       (make-request mocked-conn "not-an-email" "alice"))]
+            (is (= 400 (:status resp)))
+            (is (= :invalid-email (-> resp :body :error)))
+            ;; DB unchanged
+            (let [user (find-user (d/db mocked-conn) "alice")]
+              (is (= "alice@test.com" (:orcpub.user/email user)))
+              (is (nil? (:orcpub.user/pending-email user))))))))))
+
+(deftest test-email-change-nil-email
+  (with-conn conn
+    (let [mocked-conn (dm/fork-conn conn)]
+      (seed-users mocked-conn)
+      (testing "Nil new-email returns 400 :invalid-email"
+        (with-redefs [routes/send-email-change-verification (fn [& _] nil)]
+          (let [resp (routes/request-email-change
+                       (make-request mocked-conn nil "alice"))]
+            (is (= 400 (:status resp)))
+            (is (= :invalid-email (-> resp :body :error))))))
+      (testing "Empty string new-email returns 400 :invalid-email"
+        (with-redefs [routes/send-email-change-verification (fn [& _] nil)]
+          (let [resp (routes/request-email-change
+                       (make-request mocked-conn "" "alice"))]
+            (is (= 400 (:status resp)))
+            (is (= :invalid-email (-> resp :body :error)))))))))
+
+(deftest test-email-change-no-auth
+  (with-conn conn
+    (let [mocked-conn (dm/fork-conn conn)]
+      (seed-users mocked-conn)
+      (testing "Request without identity returns 400 :user-not-found"
+        (with-redefs [routes/send-email-change-verification (fn [& _] nil)]
+          (let [resp (routes/request-email-change
+                       {:transit-params {:new-email "x@test.com"}
+                        :db (d/db mocked-conn)
+                        :conn mocked-conn
+                        :identity nil
+                        :scheme :https
+                        :headers {"host" "localhost"}})]
+            (is (= 400 (:status resp)))
+            (is (= :user-not-found (-> resp :body :error)))))))))
+
+(deftest test-email-send-failure-rolls-back
+  (with-conn conn
+    (let [mocked-conn (dm/fork-conn conn)]
+      (seed-users mocked-conn)
+      (testing "When email send fails, pending-email is retracted and returns 500"
+        (with-redefs [routes/send-email-change-verification
+                      (fn [& _] (throw (Exception. "SMTP down")))]
+          (let [resp (routes/request-email-change
+                       (make-request mocked-conn "newalice@test.com" "alice"))]
+            (is (= 500 (:status resp)))
+            (is (= :email-send-failed (-> resp :body :error)))
+            ;; Full rollback: pending-email, verification-key, and verification-sent all cleared
+            (let [user (find-user (d/db mocked-conn) "alice")]
+              (is (nil? (:orcpub.user/pending-email user)))
+              (is (nil? (:orcpub.user/verification-key user)))
+              (is (nil? (:orcpub.user/verification-sent user)))
+              (is (= "alice@test.com" (:orcpub.user/email user))))))))))
+
+(deftest test-expired-verification-cleans-pending
+  (with-conn conn
+    (let [mocked-conn (dm/fork-conn conn)]
+      (seed-users mocked-conn)
+      (testing "Expired verification link clears stale pending-email"
+        (with-redefs [routes/send-email-change-verification (fn [& _] nil)]
+          ;; Request a change so pending-email is set
+          (routes/request-email-change
+            (make-request mocked-conn "newalice@test.com" "alice"))
+          (let [user (find-user (d/db mocked-conn) "alice")
+                key  (:orcpub.user/verification-key user)]
+            ;; Force-expire by backdating verification-sent past the 24h window
+            @(d/transact mocked-conn
+               [{:db/id (:db/id user)
+                 :orcpub.user/verification-sent
+                 (java.util.Date. (- (System/currentTimeMillis) (* 25 60 60 1000)))}])
+            (let [vresp (routes/verify {:query-params {:key key}
+                                        :db           (d/db mocked-conn)
+                                        :conn         mocked-conn})]
+              ;; Must redirect to failed, not success
+              (is (= 302 (:status vresp)))
+              (is (= failed-path (redirect-location vresp)))
+              ;; All pending state cleaned up, original email unchanged
+              (let [updated (find-user (d/db mocked-conn) "alice")]
+                (is (nil? (:orcpub.user/pending-email updated)))
+                (is (nil? (:orcpub.user/verification-key updated)))
+                (is (= "alice@test.com" (:orcpub.user/email updated)))))))))))
+
+(deftest test-race-condition-email-claimed-between-request-and-verify
+  (with-conn conn
+    (let [mocked-conn (dm/fork-conn conn)]
+      (seed-users mocked-conn)
+      (testing "If target email is claimed by another user before verify, swap is rejected"
+        (with-redefs [routes/send-email-change-verification (fn [& _] nil)]
+          ;; Alice requests change to unclaimed@test.com
+          (routes/request-email-change
+            (make-request mocked-conn "unclaimed@test.com" "alice"))
+          (let [user (find-user (d/db mocked-conn) "alice")
+                key  (:orcpub.user/verification-key user)]
+            ;; Meanwhile, someone else claims that email
+            @(d/transact mocked-conn
+               [{:orcpub.user/username  "charlie"
+                 :orcpub.user/email     "unclaimed@test.com"
+                 :orcpub.user/password  (hashers/encrypt "pass789")
+                 :orcpub.user/verified? true}])
+            ;; Alice clicks verify — should be rejected
+            (let [vresp (routes/verify {:query-params {:key key}
+                                        :db           (d/db mocked-conn)
+                                        :conn         mocked-conn})]
+              (is (= 302 (:status vresp)))
+              (is (= failed-path (redirect-location vresp)))
+              ;; Alice's email unchanged, pending cleaned up
+              (let [updated (find-user (d/db mocked-conn) "alice")]
+                (is (= "alice@test.com" (:orcpub.user/email updated)))
+                (is (nil? (:orcpub.user/pending-email updated)))
+                (is (nil? (:orcpub.user/verification-key updated)))))))))))
+
+(deftest test-rate-limiting
+  (with-conn conn
+    (let [mocked-conn (dm/fork-conn conn)]
+      (seed-users mocked-conn)
+      (testing "Immediate resend of same email is blocked (email still in transit)"
+        (with-redefs [routes/send-email-change-verification (fn [& _] nil)]
+          (let [resp1 (routes/request-email-change
+                        (make-request mocked-conn "new1@test.com" "alice"))]
+            (is (= 200 (:status resp1)))
+            ;; Immediate resend — within 1-min transit zone, should be blocked
+            (let [resp2 (routes/request-email-change
+                          (make-request mocked-conn "new1@test.com" "alice"))]
+              (is (= 429 (:status resp2)))
+              ;; retry-after-secs counts down to 1-min mark (resend window)
+              (is (pos? (-> resp2 :body :retry-after-secs)))
+              (is (<= (-> resp2 :body :retry-after-secs) 60))))))
+
+      (testing "Different email within 5 minutes is rate-limited"
+        (with-redefs [routes/send-email-change-verification (fn [& _] nil)]
+          (let [resp (routes/request-email-change
+                       (make-request mocked-conn "new2@test.com" "alice"))]
+            (is (= 429 (:status resp)))
+            ;; retry-after-secs counts down to 5-min mark
+            (is (pos? (-> resp :body :retry-after-secs)))
+            ;; pending-email unchanged
+            (let [user (find-user (d/db mocked-conn) "alice")]
+              (is (= "new1@test.com" (:orcpub.user/pending-email user)))))))
+
+      (testing "Resend of same email after 1 min is allowed (free resend)"
+        (with-redefs [routes/send-email-change-verification (fn [& _] nil)]
+          ;; Backdate verification-sent to 2 minutes ago (past 1-min transit, within 5-min cooldown)
+          (let [user (find-user (d/db mocked-conn) "alice")]
+            @(d/transact mocked-conn
+               [{:db/id (:db/id user)
+                 :orcpub.user/verification-sent
+                 (java.util.Date. (- (System/currentTimeMillis) (* 2 60 1000)))}]))
+          (let [resp (routes/request-email-change
+                       (make-request mocked-conn "new1@test.com" "alice"))]
+            (is (= 200 (:status resp)))))))))
+
+(deftest test-second-change-replaces-pending
+  (with-conn conn
+    (let [mocked-conn (dm/fork-conn conn)]
+      (seed-users mocked-conn)
+      (testing "After rate-limit window, a new request overwrites old pending-email"
+        (with-redefs [routes/send-email-change-verification (fn [& _] nil)]
+          ;; First request
+          (routes/request-email-change
+            (make-request mocked-conn "old-pending@test.com" "alice"))
+          (let [user (find-user (d/db mocked-conn) "alice")
+                old-key (:orcpub.user/verification-key user)]
+            ;; Backdate verification-sent past the 5-min rate limit window
+            @(d/transact mocked-conn
+               [{:db/id (:db/id user)
+                 :orcpub.user/verification-sent
+                 (java.util.Date. (- (System/currentTimeMillis) (* 6 60 1000)))}])
+            ;; Second request should succeed and overwrite pending-email
+            (let [resp (routes/request-email-change
+                         (make-request mocked-conn "new-pending@test.com" "alice"))]
+              (is (= 200 (:status resp)))
+              (let [updated (find-user (d/db mocked-conn) "alice")]
+                (is (= "new-pending@test.com" (:orcpub.user/pending-email updated)))
+                ;; Verification key should be replaced so old link is dead
+                (is (not= old-key (:orcpub.user/verification-key updated)))))))))))


### PR DESCRIPTION
## Summary

Review and hardening of #644 (datdamnzotz: allow users to update email).
Fixes 7 issues found during code review, adds 8 hardening measures,
and provides test coverage and documentation for the email system.

### Bug fixes
- Silent email send failure: full rollback of pending-email,
  verification-key, and verification-sent
- Case-insensitive email-query (guards against mixed-case legacy data)
- Verification key invalidated after use (link can't be reused)
- Stale pending state cleaned up on expired verification links
- Redundant `verified?` reassertion removed from email swap

### Hardening
- Race-condition guard at verify time: re-checks email availability
  before swapping, in case another user claimed it since the request
- Nil-username guard in request-email-change (Datomic crashes on nil input)
- `verification-sent` retracted after verify (prevents stale rate-limit data)

### Rate limiting
- 3-zone system: 0–1 min blocked (email in transit), 1–5 min free
  resend (same email only, no DB write), 5+ min open
- 429 responses include `retry-after-secs` for client countdown

### Client UX
- Confirm-email field with client-side format + match validation
- Contextual error messages: "on its way, resend in N seconds" vs
  "wait N minutes"
- Resend button on pending email (server rate-limited)
- Pending email shown in sent confirmation (not just "your new address")
- Display uses server-canonical (lowercased/trimmed) email

### Convention fixes
- Transit-params destructured as map (matches codebase convention)
- Separate email template for email-change vs registration

### Tests
- 11 new tests covering: happy path, duplicate rejection,
  same-as-current, invalid format, nil/empty email, no auth, send
  failure rollback, expired verification, race condition, rate limiting
  (all 3 zones), and pending email replacement

### Docs
- `docs/email-system.md`: all 4 email flows, schema, rate-limit zones,
  expiration windows, file map, known issues

### Deferred
- Email schema lacks `:db.unique/value` constraint (needs data migration)
- No `pending-email` conflict check across users (verify-time guard
  catches it; adding request-time check creates a squat vector)

## Checklist
- [x] The code change is tested and works locally
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] There is no commented out code in this PR
- [x] My changes generate no new warnings
